### PR TITLE
Fixes #84 by targetting just header links to be white

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13578,7 +13578,7 @@ td.recaptcha_label {
   color: #fff;
 }
 
-.accordion-item a:link {
+.accordion-header a:link {
   color: #fff;
   text-decoration: none;
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -1582,7 +1582,7 @@ html {
     padding-top: 0;
     color: #fff;
   }
-  .accordion-item a:link {
+  .accordion-header a:link {
     color: #fff;
     text-decoration: none;
   }


### PR DESCRIPTION
The missing link is now default blue.
Also catches and link to HM Customs in top FAQ